### PR TITLE
Correct a test of promise error case.

### DIFF
--- a/test/unit/migration_dsl_spec.js
+++ b/test/unit/migration_dsl_spec.js
@@ -137,12 +137,13 @@ shared.examplesFor('supporting Promise interface', function(opts) {
         sandbox.stub(opts.internalObject, opts.internalMethodName).yields(new Error('problem'));
       });
 
-      it('returns rejected Promise unless callback is specified', function () {
-        return opts.run()
+      it('returns rejected Promise unless callback is specified', function (done) {
+        opts.run()
           .catch(function (err) {
             err.should.be.instanceOf(Error);
             err.message.should.equal('problem');
-          });
+            done();
+          })
       });
     });
   });


### PR DESCRIPTION
### [LM-3630](https://locomote.atlassian.net/browse/LM-3630)

Ensure fail of a promise error case test.
The applied solution is not the best, but is the only possible without `co-mocha` (https://locomote.atlassian.net/wiki/spaces/GEN/pages/89031570/Testing+an+error+case+of+a+Promise-based+function).

## QA

Not required.

## Release notes

Users are not affected.