### PR TITLE
Support old migrations when switching from coffee to js

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,19 @@
+### v4.0.0
+- Support all existing migrations when switching from coffee to js and vice versa
+  ( using migration file name without extension for checking if migration
+  is applied and on deleting migration record from orm_migrations table )
+
+  **Example**: project with already executed migration `001-migration.coffee`
+  ```
+  > SELECT * from orm_migrations;
+  | migration                                              |
+  |--------------------------------------------------------|
+  | 001-migration.coffe                                |
+  ```
+  After conversion `001-migration.coffee` to `001-migration.js`
+  **node-migrate-orm2** will identify converted file as executed and will not
+  re-run this migration again.
+
 ### v3.0.0
 - Add Promises support to migration methods
 - Add Promiess support to `Task` methods(`generate`, `up`, `down`).

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -38,7 +38,7 @@ Migration.prototype.allV1 = function(cb) {
 }
 
 Migration.prototype.delete = function(migration, cb) {
-  this.dsl.execQuery('DELETE FROM orm_migrations where migration = ?;', [migration], cb);
+  this.dsl.execQuery('DELETE FROM orm_migrations where migration ~ ?;', [migration], cb);
 }
 
 Migration.prototype.ensureMigrationsTable = function(cb) {

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -153,7 +153,11 @@ Migrator.prototype.performMigration = function(direction, migrationName, cb) {
 
     // is a migration module applied ?
     var isApplied = function(mod) {
-      return _.includes(appliedMigrations, mod.file);
+      fileName = path.parse(mod.file).name;
+      var res = _.some(appliedMigrations, function(appliedMigration) {
+        return appliedMigration.match(fileName);
+      });
+      return res;
     }
     if(direction === 'up') { // up -> reject the applied migrations
       migrationModules = _.reject(migrationModules, isApplied);
@@ -173,7 +177,8 @@ Migrator.prototype.performMigration = function(direction, migrationName, cb) {
           if (direction === 'up') {
             self.migration.save(mod.file, done);
           } else {
-            self.migration.delete(mod.file, done);
+            fileName = path.parse(mod.file).name;
+            self.migration.delete(fileName, done);
           }
         };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-orm2",
-  "version": "3.0.2",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-orm2",
-  "version": "2.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -23,6 +23,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -526,6 +531,12 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
       "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
+      "dev": true
+    },
+    "shared-examples-for": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/shared-examples-for/-/shared-examples-for-0.1.3.tgz",
+      "integrity": "sha1-QHe7dSQnERh3ltczv3ZSdIzmIVQ=",
       "dev": true
     },
     "should": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-orm2",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A library providing migrations using ORM2's model DSL leveraging Visionmedia's node-migrate.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-orm2",
-  "version": "3.0.2",
+  "version": "4.0.2",
   "description": "A library providing migrations using ORM2's model DSL leveraging Visionmedia's node-migrate.",
   "main": "index.js",
   "repository": {

--- a/test/integration/migration_spec.js
+++ b/test/integration/migration_spec.js
@@ -147,18 +147,37 @@ describe('Migration', function () {
   });
 
   describe('#delete', function() {
-    before(function(done) {
-      reload(function() {
-        migration.delete('002-create-cats.js', done);
+    describe('when file with extension', function() {
+      before(function(done) {
+        reload(function() {
+          migration.delete('002-create-cats.js', done);
+        });
+      });
+
+      it('removed the migration', function(done) {
+        migration.all(function(err, migrations) {
+          should.not.exist(err);
+          migrations.should.have.length(1);
+          _.first(migrations).should.eql('001-create-pets.js');
+          done();
+        });
       });
     });
 
-    it('removed the migration', function(done) {
-      migration.all(function(err, migrations) {
-        should.not.exist(err);
-        migrations.should.have.length(1);
-        _.first(migrations).should.eql('001-create-pets.js');
-        done();
+    describe('when file without extension', function() {
+      before(function(done) {
+        reload(function() {
+          migration.delete('002-create-cats', done);
+        });
+      });
+
+      it('removed the migration', function(done) {
+        migration.all(function(err, migrations) {
+          should.not.exist(err);
+          migrations.should.have.length(1);
+          _.first(migrations).should.eql('001-create-pets.js');
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
### The problem
`node-migrate-orm2` saves migration file names with extensions in `orm_migrations` table to identify which migration is already executed and which is not. In cases when developer decides to switch from CoffeeScript to JavaScript on existing project or vice-verse there is no possibility to maintain old migrations. For example if we have migrations:
```
001-migration.coffee
002-migration.coffee
```
and then decaffeinate them to JS:

```
001-migration.js
002-migration.js
```
it will receive an error due to all migrations will be executed again because `001-migration.coffee` saved to db table early does not match `001-migration.js`

### The solution
Using migration file name without extension for checking if migration is
applied and on deleting migration record from orm_migrations table