### PR TITLE
Update sql-ddl-sync dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bluebird": "^3.5.1",
     "lodash": "4.17.10",
     "mkdirp": "0.5.1",
-    "sql-ddl-sync": "git://github.com/dresende/node-sql-ddl-sync.git#v0.3.14"
+    "sql-ddl-sync": "https://github.com/dresende/node-sql-ddl-sync.git#v0.3.14"
   },
   "devDependencies": {
     "mocha": "5.2.0",


### PR DESCRIPTION
Shall we move the dependency url from `git` to `https`?