### PR TITLE
LM-10625 - Add foreign keys and corresponding indexes to CBT database

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+### v4.0.6
+- Allow to add foreign keys with custon constraint name and on delete action
+
 ### v4.0.5
 - Update packages to fix security vulnerabilities
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-### v4.0.6
+### v4.1.0
 - Allow to add foreign keys with custon constraint name and on delete action
 
 ### v4.0.5

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ The full list of operations available through ```this```:
 * addPrimaryKey
 * dropPrimaryKey
 * addForeignKey
+* addForeignKeyConstraint
 * dropForeignKey
+* dropForeignKeyConstraint
 * execQuery
 
 These operations are depicted in the examples folder.

--- a/lib/migration-dsl.js
+++ b/lib/migration-dsl.js
@@ -148,7 +148,7 @@ MigrationDSL.prototype = {
   dropForeignKeyConstraint: addPromiseInterface(
     function (collectionName, constraintName, cb) {
       const sql = "ALTER TABLE ?? DROP CONSTRAINT ??;";
-	    driver.execQuery(sql, [collectionName, constraintName], cb);
+	    this.driver.execQuery(sql, [collectionName, constraintName], cb);
     }
   ),
 

--- a/lib/migration-dsl.js
+++ b/lib/migration-dsl.js
@@ -129,7 +129,7 @@ MigrationDSL.prototype = {
 
       const sql = `ALTER TABLE ?? ADD CONSTRAINT ?? FOREIGN KEY(??) REFERENCES ?? (??) ${onDeleteMethod};`;
 
-	    this.driver.execQuery(sql, [collectionName, options.name, options.name, options.references.table, options.references.column], cb);
+	    this.driver.execQuery(sql, [collectionName, options.constraintName, options.name, options.references.table, options.references.column], cb);
     }
   ),
 

--- a/lib/migration-dsl.js
+++ b/lib/migration-dsl.js
@@ -117,13 +117,19 @@ MigrationDSL.prototype = {
 
   addForeignKey: addPromiseInterface(
     function (collectionName, options, cb) {
+      this.Dialect.addForeignKey(this.driver, collectionName, options, cb);
+    }
+  ),
+
+  addForeignKeyConstraint: addPromiseInterface(
+    function (collectionName, options, cb) {
       let onDeleteMethod = "";
       
       switch (options.onDelete) {
-        case "cascade":
+        case "CASCADE":
           onDeleteMethod = "ON DELETE CASCADE";
           break;
-        case "set_null":
+        case "SET_NULL":
           onDeleteMethod = "ON DELETE SET NULL";
       }
 
@@ -136,6 +142,13 @@ MigrationDSL.prototype = {
   dropForeignKey: addPromiseInterface(
     function (collectionName, columnName, cb) {
       this.Dialect.dropForeignKey(this.driver, collectionName, columnName, cb);
+    }
+  ),
+
+  dropForeignKeyConstraint: addPromiseInterface(
+    function (collectionName, constraintName, cb) {
+      const sql = "ALTER TABLE ?? DROP CONSTRAINT ??;";
+	    driver.execQuery(sql, [collectionName, constraintName], cb);
     }
   ),
 

--- a/lib/migration-dsl.js
+++ b/lib/migration-dsl.js
@@ -117,20 +117,19 @@ MigrationDSL.prototype = {
 
   addForeignKey: addPromiseInterface(
     function (collectionName, options, cb) {
-      // this.Dialect.addForeignKey(this.driver, collectionName, options, cb);
-
-      const sql = "ALTER TABLE ?? ADD FOREIGN KEY(??) REFERENCES ?? (??) ??;"
-      const onDeleteMethod;
+      let onDeleteMethod = "";
       
       switch (options.onDelete) {
         case "cascade":
           onDeleteMethod = "ON DELETE CASCADE";
           break;
         case "set_null":
-          onDeleteMethod += "ON DELETE SET NULL";
+          onDeleteMethod = "ON DELETE SET NULL";
       }
 
-	    driver.execQuery(sql, [collectionName, options.name, options.references.table, options.references.column, onDeleteMethod], cb);
+      const sql = `ALTER TABLE ?? ADD CONSTRAINT ?? FOREIGN KEY(??) REFERENCES ?? (??) ${onDeleteMethod};`;
+
+	    this.driver.execQuery(sql, [collectionName, options.name, options.name, options.references.table, options.references.column], cb);
     }
   ),
 

--- a/lib/migration-dsl.js
+++ b/lib/migration-dsl.js
@@ -124,7 +124,7 @@ MigrationDSL.prototype = {
   addForeignKeyConstraint: addPromiseInterface(
     function (collectionName, options, cb) {
       let onDeleteMethod = "";
-      
+
       switch (options.onDelete) {
         case "CASCADE":
           onDeleteMethod = "ON DELETE CASCADE";
@@ -135,7 +135,7 @@ MigrationDSL.prototype = {
 
       const sql = `ALTER TABLE ?? ADD CONSTRAINT ?? FOREIGN KEY(??) REFERENCES ?? (??) ${onDeleteMethod};`;
 
-	    this.driver.execQuery(sql, [collectionName, options.constraintName, options.name, options.references.table, options.references.column], cb);
+      this.driver.execQuery(sql, [collectionName, options.constraintName, options.name, options.references.table, options.references.column], cb);
     }
   ),
 
@@ -148,7 +148,7 @@ MigrationDSL.prototype = {
   dropForeignKeyConstraint: addPromiseInterface(
     function (collectionName, constraintName, cb) {
       const sql = "ALTER TABLE ?? DROP CONSTRAINT ??;";
-	    this.driver.execQuery(sql, [collectionName, constraintName], cb);
+      this.driver.execQuery(sql, [collectionName, constraintName], cb);
     }
   ),
 

--- a/lib/migration-dsl.js
+++ b/lib/migration-dsl.js
@@ -117,7 +117,20 @@ MigrationDSL.prototype = {
 
   addForeignKey: addPromiseInterface(
     function (collectionName, options, cb) {
-      this.Dialect.addForeignKey(this.driver, collectionName, options, cb);
+      // this.Dialect.addForeignKey(this.driver, collectionName, options, cb);
+
+      const sql = "ALTER TABLE ?? ADD FOREIGN KEY(??) REFERENCES ?? (??) ??;"
+      const onDeleteMethod;
+      
+      switch (options.onDelete) {
+        case "cascade":
+          onDeleteMethod = "ON DELETE CASCADE";
+          break;
+        case "set_null":
+          onDeleteMethod += "ON DELETE SET NULL";
+      }
+
+	    driver.execQuery(sql, [collectionName, options.name, options.references.table, options.references.column, onDeleteMethod], cb);
     }
   ),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-orm2",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-orm2",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-orm2",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "A library providing migrations using ORM2's model DSL leveraging Visionmedia's node-migrate.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-orm2",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "description": "A library providing migrations using ORM2's model DSL leveraging Visionmedia's node-migrate.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
### [LM-10625](https://mttnow.atlassian.net/browse/LM-10625)

Details added on confluence page : 

-DB admin: generates missing foreign key and index creation statements for postgres.

-Developer should implement migration file similar to 023-add-primary-keys.js for foreign keys and indexes using addIndex and addForeignKey methods.-developer runs locally  the integration tests to see if the added foreign keys cause crash somewhere the tests.-problems occured if minor or fitin the estimate can be fixed if not will be raported in a new jira task to be handled in a second phase.-the foreign keys that caused problems that could not be fixed will be removed from migration file and code and readded later after bug fixed.-check if the ORM models give us additional foreign keys and add those as well to the migration

-DB admin:Restores uat db temporarily and runs the sql scripts attached to create foreign keys and indexes on real data .Some foreign keys will fail due to data inconsistencies.Before code changes are merged/committed inconsistencies in production should be fixed,first creating an excel with these and the suggested action :a)remove rows in foreign table that do not have correspondence in primary table orb)update foreign id to an existing id orc)add the row in the primary tableAfter actions confirmed cleanup data in production database.

with some weeks before release the same process should be done to check inconsistencies that appeared meantime.These could hide possible bugs that need to be addressed and the corresponding foreign keys should be removed from the migrationand bugs reported in the new jira task.

QA: manual tests should be done in staging/uat to ensure main flows are fine. Problems occured that can't be fixed fast should be reported and foreign keys removed from migration and code.

