### PR TITLE
[LM-10984] - Update libraries in CBT module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -204,9 +204,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
     },
     "lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "async": "2.6.1",
     "bluebird": "^3.5.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "mkdirp": "0.5.1",
     "sql-ddl-sync": "0.3.14"
   },


### PR DESCRIPTION
Description
The following libraries used by CBT have been reported with critical and high vulnerability scores by Github:

1. CBT module:

lodash (script/release/package.json) - upgrade from 4.17.11 to 4.17.13

2. node-migrate-orm2 module:

lodash - upgrade to min 4.17.13

Regression Testing is required