### PR TITLE
Update async package to resolve security vulnerabilities.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,14 @@
+### v5.0.0
+- Update `async` package from v2 to v3 to resolve security vulnerabilities ([5](../../pull/5))
+- Drop support for node < 6 (due to `async` package update)
+
 ### v4.3.0
-- Add `renameTable`
+- Add `renameTable` ([4](../../pull/4))
 
 ### v4.2.0
-- Add MySQL & PostgreSQL `defaultExpression` to allow setting default values via DB functions
-  - MySQL: `id: { type : 'text', key: true, defaultExpression: 'uuid()' }` (requires MySQL 8.0.13+)
-  - PostgreSQL: `id: { type : 'uuid', key: true, defaultExpression: 'uuid_generate_v4()' }`
+- Add MySQL & PostgreSQL `defaultExpression` to allow setting default values via DB functions ([3](../../pull/3))
+  - MySQL: `id: { type : 'text', key: true, defaultExpression: 'uuid()' }` (requires MySQL 8.0.13+) ([2](../../pull/2))
+  - PostgreSQL: `id: { type : 'uuid', key: true, defaultExpression: 'uuid_generate_v4()' }` ([2](../../pull/2))
 
 ### v4.1.6
 - Add PostgreSQL UUID support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-orm2",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -83,19 +83,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
-      }
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -519,9 +509,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -674,12 +664,12 @@
       }
     },
     "orm": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/orm/-/orm-6.2.0.tgz",
-      "integrity": "sha512-S6kwrKxSYleH5c7NFq/v9xsV9JttaiMUz8faka4/dIdKmPTNQu6F3Y8thGrMl55WTXcgJCybcVDxNm1gubSnuA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/orm/-/orm-7.0.0.tgz",
+      "integrity": "sha512-8lDr7RlnSTLIf/F+aMZieHbwFaLBuVj0r7xxP94DQtuHoQlbtVB3R2WAK+awfzkOnVkfQRqrdraZGCox27oXjQ==",
       "dev": true,
       "requires": {
-        "async": "~2.6.3",
+        "async": "~3.2.3",
         "bluebird": "3.5.1",
         "enforce": "0.1.7",
         "hat": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-orm2",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "description": "A library providing migrations using ORM2's model DSL leveraging Visionmedia's node-migrate.",
   "main": "index.js",
   "repository": {
@@ -16,7 +16,7 @@
     "test": "ORM_PROTOCOL=postgres mocha test && ORM_PROTOCOL=mysql mocha test"
   },
   "dependencies": {
-    "async": "~2.6.3",
+    "async": "~3.2.3",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.21",
     "mkdirp": "~0.5.5",
@@ -25,7 +25,7 @@
   "devDependencies": {
     "mocha": "9.2.2",
     "mysql": "^2.18.1",
-    "orm": "6.2.0",
+    "orm": "7.0.0",
     "pg": "~8.7.1",
     "rimraf": "2.6.1",
     "shared-examples-for": "0.1.3",


### PR DESCRIPTION
This also drops support for nodejs < 6 due to changes in that package.